### PR TITLE
Replace rfc3987 with rfc3986 - issue #36

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ target/
 *.sublime-workspace
 shippable/*
 /docs/site
+.python-version

--- a/jsontableschema/types.py
+++ b/jsontableschema/types.py
@@ -16,7 +16,7 @@ import base64
 import binascii
 import uuid
 from dateutil.parser import parse as date_parse
-import rfc3987
+from rfc3986 import is_valid_uri
 import unicodedata
 import jsonschema
 from future.utils import raise_with_traceback
@@ -161,11 +161,9 @@ class StringType(LengthConstraintMixin, JTSType):
     def cast_uri(self, value):
         if not self._type_check(value):
             return False
-
-        try:
-            rfc3987.parse(value, rule="URI")
+        if is_valid_uri(value, require_scheme=True):
             return value
-        except ValueError:
+        else:
             raise exceptions.InvalidURI('{0} is not a valid uri'.format(value))
 
     def cast_binary(self, value):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 click>=3.3
 requests>=2.5.1
 python-dateutil>=2.4.0
-rfc3987>=1.3.4
+rfc3986>=0.3.0
 jsonschema>=2.5.1
 future>=0.15.2

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ dependencies = [
     'click>=3.3',
     'requests>=2.5.1',
     'python-dateutil>=2.4.0',
-    'rfc3987>=1.3.4',
+    'rfc3986>=0.3.0',
     'jsonschema>=2.5.1',
     'future>=0.15.2'
 ]


### PR DESCRIPTION
Currently, on the the URI scheme is set to be required as that was the minimum to get all tests passing. 
Closes #36 