### PR TITLE
Fields aren't required by default

### DIFF
--- a/jsontableschema/model.py
+++ b/jsontableschema/model.py
@@ -40,7 +40,6 @@ class SchemaModel(object):
     FALSE_VALUES = [False] + utilities.FALSE_VALUES
 
     DEFAULTS = {
-        'constraints': {'required': True},
         'format': 'default',
         'type': 'string'
     }
@@ -72,7 +71,7 @@ class SchemaModel(object):
     @property
     def required_headers(self):
         _raw = [f['name'] for f in self.as_python.get('fields')
-                if f['constraints']['required']]
+                if f.get('constraints', {}).get('required')]
         if self.case_insensitive_headers:
             return [name.lower() for name in _raw]
         return _raw
@@ -153,13 +152,6 @@ class SchemaModel(object):
             # ensure we have a default format if no format was declared
             if not field.get('format'):
                 field['format'] = self.DEFAULTS['format']
-
-            # ensure we have a minimum constraints declaration
-            if not field.get('constraints'):
-                field['constraints'] = self.DEFAULTS['constraints']
-
-            elif field['constraints'].get('required') is None:
-                field['constraints']['required'] = self.DEFAULTS['constraints']['required']
 
         return schema
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -116,6 +116,16 @@ class TestModel(base.BaseTestCase):
         m = model.SchemaModel(self.schema_min)
         self.assertEqual(len(m.get_fields_by_type('string')), 2)
 
+    def test_fields_arent_required_by_default(self):
+        schema = {
+            "fields": [
+                {"name": "id", "constraints": {"required": True}},
+                {"name": "label"}
+            ]
+        }
+        m = model.SchemaModel(schema)
+        self.assertEqual(len(m.required_headers), 1)
+
 
 class TestData(base.BaseTestCase):
     def setUp(self):


### PR DESCRIPTION
For the reasoning behind it, check
https://github.com/dataprotocols/dataprotocols/issues/167

Related to #44 